### PR TITLE
feat(middleware): add JWT authentication middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eser/go-service
 go 1.23.0
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/getkin/kin-openapi v0.127.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/getkin/kin-openapi v0.127.0 h1:Mghqi3Dhryf3F8vR370nN67pAERW+3a95vomb3MAREY=
 github.com/getkin/kin-openapi v0.127.0/go.mod h1:OZrfXzUfGrNbsKj+xmFBx6E5c6yH3At/tAKSc2UszXM=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=

--- a/pkg/app/mod.go
+++ b/pkg/app/mod.go
@@ -45,6 +45,7 @@ func RegisterRoutes(routes httpfx.Router, appConfig *AppConfig) {
 	routes.Use(middlewares.ErrorHandlerMiddleware())
 	routes.Use(middlewares.ResponseTimeMiddleware())
 	routes.Use(middlewares.CorrelationIdMiddleware())
+	routes.Use(middlewares.AuthMiddleware())
 	routes.Use(middlewares.CorsMiddleware())
 
 	routes.

--- a/pkg/bliss/httpfx/middlewares/auth-middleware.go
+++ b/pkg/bliss/httpfx/middlewares/auth-middleware.go
@@ -1,0 +1,52 @@
+package middlewares
+
+import (
+	"github.com/dgrijalva/jwt-go"
+	"github.com/eser/go-service/pkg/bliss/httpfx"
+	"strings"
+	"time"
+)
+
+func AuthMiddleware() httpfx.Handler {
+	return func(ctx *httpfx.Context) httpfx.Response {
+		authHeader := ctx.Request.Header.Get("Authorization")
+		if authHeader == "" {
+			return httpfx.Response{
+				StatusCode: 401,
+				Body:       []byte("Authorization header is missing"),
+			}
+		}
+
+		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+		if tokenString == "" {
+			return httpfx.Response{
+				StatusCode: 401,
+				Body:       []byte("Token is missing"),
+			}
+		}
+
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return httpfx.Response{StatusCode: 401, Body: nil}, nil
+			}
+			return []byte("secret"), nil
+		})
+
+		if err != nil || !token.Valid {
+			return httpfx.Response{StatusCode: 401, Body: []byte(err.Error())}
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok || !token.Valid {
+			return httpfx.Response{StatusCode: 401, Body: []byte("Invalid token")}
+		}
+
+		if exp, ok := claims["exp"].(float64); ok {
+			if time.Unix(int64(exp), 0).Before(time.Now()) {
+				return httpfx.Response{StatusCode: 401, Body: []byte("Token is expired")}
+			}
+		}
+
+		return ctx.Next()
+	}
+}

--- a/pkg/bliss/httpfx/middlewares/auth-middleware_test.go
+++ b/pkg/bliss/httpfx/middlewares/auth-middleware_test.go
@@ -1,0 +1,76 @@
+package middlewares
+
+import (
+	"github.com/eser/go-service/pkg/bliss/httpfx"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func createToken(secret string, exp time.Time) string {
+	claims := jwt.MapClaims{
+		"exp": exp.Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte(secret))
+	return tokenString
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	tests := []struct {
+		name         string
+		token        string
+		expectedCode int
+	}{
+		{
+			name:         "No Authorization Header",
+			token:        "",
+			expectedCode: http.StatusUnauthorized,
+		},
+		{
+			name:         "Invalid Token Format",
+			token:        "InvalidToken",
+			expectedCode: http.StatusUnauthorized,
+		},
+		{
+			name:         "Expired Token",
+			token:        createToken("secret", time.Now().Add(-time.Hour)),
+			expectedCode: http.StatusUnauthorized,
+		},
+		{
+			name:         "Valid Token",
+			token:        createToken("secret", time.Now().Add(time.Hour)),
+			expectedCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tt.token)
+			}
+			res := httptest.NewRecorder()
+			ctx := httpfx.Context{
+				Request:        req,
+				ResponseWriter: res,
+			}
+
+			middleware := AuthMiddleware()
+			result := middleware(&ctx)
+
+			if result.StatusCode != tt.expectedCode {
+				t.Errorf("Expected status code %d, got %d", tt.expectedCode, result.StatusCode)
+			}
+
+			if tt.expectedCode == http.StatusOK {
+				if res.Header().Get("Authorization") == "" {
+					t.Error("Authorization header is missing")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Implemented AuthMiddleware in the middlewares package to validate JWT tokens.
- Middleware checks for Authorization header and verifies the token using HMAC signing method.
- Added token expiration handling to ensure expired tokens are rejected.
- Returns appropriate HTTP status codes and error messages for missing or invalid tokens.

## Fixes issue


Fixes #3

## Changes proposed

- Implemented AuthMiddleware in the middlewares package to validate JWT tokens.
- Middleware checks for Authorization header and verifies the token using HMAC signing method.
- Added token expiration handling to ensure expired tokens are rejected.
- Returns appropriate HTTP status codes and error messages for missing or invalid tokens.

## Check List 

- [x] The title of my pull request is a short description of the requested
      changes.
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] This PR does not contain plagiarized content.
- [x] My submissions follows the **Submission Rules**
- [x] I have read and accepted the **Terms and Conditions**

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

Please contact me for any reason. @sameterkanboz 
